### PR TITLE
Add querystrings for GET request URL

### DIFF
--- a/lib/feedly.js
+++ b/lib/feedly.js
@@ -243,7 +243,7 @@ class Feedly {
     if (method == null) { method = 'GET' }
     const u = url.parse(this.options.base)
     u.pathname = path
-
+    if (method == 'GET') { u.query = body }
     const auth = await this._getAuth()
     return utils.qrequest({
       method,


### PR DESCRIPTION
GET need to have a query string in the URL rather than the body.